### PR TITLE
Errormessage

### DIFF
--- a/src/Chirp.Infrastructure/CheepService.cs
+++ b/src/Chirp.Infrastructure/CheepService.cs
@@ -3,7 +3,7 @@ using Chirp.Infrastructure;
 using Chirp.Razor;
 using Author = Chirp.Core.Author;
 
-public record CheepViewModel(string Author, string Message, string Timestamp);
+public record CheepViewModel(string? Author, string Message, string Timestamp);
 
 public interface ICheepService
 {

--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -7,8 +7,17 @@
     Layout = "Shared/_Layout";
 }
 
+
+
 <div>
     <h2> Public Timeline </h2>
+
+    <style>
+        .text-danger {
+            color: red;
+            font-size: 0.9rem;
+        }
+    </style>
 
     @if (User.Identity.IsAuthenticated)
     {
@@ -17,6 +26,7 @@
             <form method="post">
                 <input type="text" asp-for="Message" placeholder="Write your cheep..." />
                 <button type="submit">Post</button>
+                <span asp-validation-for="Message" class="text-danger"></span>
             </form>
         </div>
     }

--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -1,5 +1,4 @@
 ﻿@page "/"
-@using Microsoft.EntityFrameworkCore
 @model Chirp.Web.Pages.PublicModel
 
 @{
@@ -19,7 +18,7 @@
         }
     </style>
 
-    @if (User.Identity.IsAuthenticated)
+    @if (User.Identity is { IsAuthenticated: true })
     {
         <div class="CheepMessageField">
             <h3>Hello, @(User.Identity!.Name)! What do you want to share today?</h3>

--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -24,9 +24,9 @@
         <div class="CheepMessageField">
             <h3>Hello, @(User.Identity!.Name)! What do you want to share today?</h3>
             <form method="post">
-                <input type="text" asp-for="Message" placeholder="Write your cheep..." />
+                <input type="text" asp-for="CheepMessage.Message" placeholder="Write your cheep..." />
                 <button type="submit">Post</button>
-                <span asp-validation-for="Message" class="text-danger"></span>
+                <span asp-validation-for="CheepMessage.Message" class="text-danger"></span>
             </form>
         </div>
     }

--- a/src/Chirp.Web/Pages/Public.cshtml.cs
+++ b/src/Chirp.Web/Pages/Public.cshtml.cs
@@ -1,39 +1,37 @@
-﻿
+﻿using System.ComponentModel.DataAnnotations;
 using Chirp.Core;
-using Chirp.Infrastructure;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Chirp.Web.Pages.Shared;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
-
 
 namespace Chirp.Web.Pages;
 
 public class PublicModel : PageModel
 {
     private readonly ICheepService _service;
-    
     private readonly SignInManager<Author> _signInManager;
-    public List<CheepViewModel> Cheeps { get; set; }  = new List<CheepViewModel>();
 
-    [BindProperty] 
+    public List<CheepViewModel> Cheeps { get; set; } = new List<CheepViewModel>();
+
+    [Required]
+    [StringLength(160, ErrorMessage = "Maximum length is 160 characters.")]
+    [MinLength(2, ErrorMessage = "Cheep must be at least 2 characters long.")]
+    [Display(Name = "Cheep")]
+    [BindProperty]
     public string? Message { get; set; }
-    
+
     public PublicModel(ICheepService service, SignInManager<Author> signInManager)
     {
         _service = service;
         _signInManager = signInManager;
     }
 
-    public ActionResult OnGet([FromQuery] int page)
+    public IActionResult OnGet([FromQuery] int page)
     {
         if (page < 1)
         {
             return Redirect($"{Request.Path}?page=1");
         }
-        
 
         Cheeps = _service.GetCheeps(page);
         return Page();
@@ -41,20 +39,29 @@ public class PublicModel : PageModel
 
     public async Task<IActionResult> OnPostAsync()
     {
+        if (string.IsNullOrWhiteSpace(Message))
+        {
+            ModelState.AddModelError("Message", "Cheep cannot be empty.");
+            return Page();
+        }
         if (!ModelState.IsValid)
         {
-            return NotFound();
+            return Page();
         }
-        else
+
+        if (User.Identity?.Name == null)
         {
-            Author author = await _service.GetAuthorByName(User.Identity.Name);
-            if( author == null)
-            {
-                return RedirectToPage("Public");
-            }
-            await _service.AddCheep(author, Message ?? throw new NullReferenceException());
+            return RedirectToPage("Public");
         }
-        // missing query 
-        return RedirectToPage("Public");
+
+        var author = await _service.GetAuthorByName(User.Identity.Name);
+        if (author == null)
+        {
+            ModelState.AddModelError(string.Empty, "Author not found.");
+            return Page();
+        }
+
+        await _service.AddCheep(author, Message!);
+        return RedirectToPage("Public", new { page = Request.Query["page"] });
     }
 }

--- a/src/Chirp.Web/Pages/Public.cshtml.cs
+++ b/src/Chirp.Web/Pages/Public.cshtml.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Chirp.Core;
+using Chirp.Web.Pages.Shared;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -12,13 +13,10 @@ public class PublicModel : PageModel
     private readonly SignInManager<Author> _signInManager;
 
     public List<CheepViewModel> Cheeps { get; set; } = new List<CheepViewModel>();
-
-    [Required]
-    [StringLength(160, ErrorMessage = "Maximum length is 160 characters.")]
-    [MinLength(1, ErrorMessage = "Cheep must be at least 1 characters long.")]
-    [Display(Name = "Cheep")]
     [BindProperty]
-    public string? Message { get; set; }
+    
+    public CheepFormatMessage CheepMessage { get; set; } = new CheepFormatMessage();
+
 
     public PublicModel(ICheepService service, SignInManager<Author> signInManager)
     {
@@ -39,7 +37,7 @@ public class PublicModel : PageModel
 
     public async Task<IActionResult> OnPostAsync()
     {
-        if (string.IsNullOrWhiteSpace(Message))
+        if (string.IsNullOrWhiteSpace(CheepMessage.Message))
         {
             ModelState.AddModelError("Message", "Cheep cannot be empty.");
             return Page();
@@ -61,7 +59,7 @@ public class PublicModel : PageModel
             return Page();
         }
 
-        await _service.AddCheep(author, Message!);
+        await _service.AddCheep(author, CheepMessage.Message);
         return RedirectToPage("Public", new { page = Request.Query["page"] });
     }
 }

--- a/src/Chirp.Web/Pages/Public.cshtml.cs
+++ b/src/Chirp.Web/Pages/Public.cshtml.cs
@@ -15,7 +15,7 @@ public class PublicModel : PageModel
 
     [Required]
     [StringLength(160, ErrorMessage = "Maximum length is 160 characters.")]
-    [MinLength(2, ErrorMessage = "Cheep must be at least 2 characters long.")]
+    [MinLength(1, ErrorMessage = "Cheep must be at least 1 characters long.")]
     [Display(Name = "Cheep")]
     [BindProperty]
     public string? Message { get; set; }

--- a/src/Chirp.Web/Pages/Shared/_CheepFormatMessage.cshtml
+++ b/src/Chirp.Web/Pages/Shared/_CheepFormatMessage.cshtml
@@ -1,5 +1,4 @@
 @using Chirp.Core
-@using Chirp.Web.Pages.Shared
 @using Microsoft.AspNetCore.Mvc.TagHelpers
 @inject SignInManager<Author> SignInManager
 @model Chirp.Web.Pages.Shared.CheepFormatMessage


### PR DESCRIPTION
added a red errormessage, so cheep can not be empty,

and refactored code in public.cshtml.cs, and deleted code redundant,

we had added the same code in CheepFormatMessage.cs and in public.cshtml.cs,

Therefore added call to class instead

And fixed warnings

